### PR TITLE
Fix URL for getting Python2.7 pip

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -68,7 +68,7 @@ RUN apt-get install -y \
     curl \
     libmagic-dev
 
-RUN curl "https://bootstrap.pypa.io/get-pip.py" -o "get-pip.py"
+RUN curl "https://bootstrap.pypa.io/2.7/get-pip.py" -o "get-pip.py"
 RUN python get-pip.py
 
 RUN mkdir /static


### PR DESCRIPTION
- use https://bootstrap.pypa.io/2.7/get-pip.py